### PR TITLE
No wolframalpha 3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1-dev
+current_version = 0.2.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/NEWS
+++ b/NEWS
@@ -4,12 +4,13 @@ Changelog
 Ticket numbers in changelog entries can be looked up by visiting
 ``https://github.com/dgw/sopel-wolfram/issue/<number>``
 
-Unreleased
-----------
+sopel-wolfram v0.2.1
+--------------------
 
 Updates:
 
 * Output now split into multiple messages when line breaks are present (#4)
+* Tell pip we do not want wolframalpha 3.0 yet (#6)
 
 sopel-wolfram v0.2.0
 --------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 sopel>=6.0,<7
-wolframalpha>=2.0
+wolframalpha>=2.0,<3.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('dev-requirements.txt') as dev_requirements_file:
 
 setup(
     name='sopel_modules.wolfram',
-    version='0.2.1-dev',
+    version='0.2.1',
     description='Wolfram|Alpha module for Sopel IRC bot framework',
     long_description=readme + '\n\n' + history,
     author='Max Gurela',

--- a/sopel_modules/wolfram/__init__.py
+++ b/sopel_modules/wolfram/__init__.py
@@ -9,5 +9,5 @@ from .wolfram import *
 
 __author__ = 'Max Gurela'
 __email__ = 'maxpowa1@gmail.com'
-__version__ = '0.2.1-dev'
+__version__ = '0.2.1'
 


### PR DESCRIPTION
Big enough code changes happened that we can't use it without changing our own code. Tell pip not to install `wolframalpha` 3.0 for now and bump version for immediate release.
