### PR TITLE
Send results longer than 3 lines as NOTICEs to calling user

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,13 @@ Changelog
 Ticket numbers in changelog entries can be looked up by visiting
 ``https://github.com/dgw/sopel-wolfram/issue/<number>``
 
+Unreleased
+----------
+
+Updates:
+
+* Results longer than 3 lines will be sent via NOTICE instead of flooding channels (#8)
+
 sopel-wolfram v0.2.1
 --------------------
 

--- a/sopel_modules/wolfram/wolfram.py
+++ b/sopel_modules/wolfram/wolfram.py
@@ -38,8 +38,12 @@ def wa_command(bot, trigger):
 
     lines = (msg or wa_query(bot.config.wolfram.app_id, trigger.group(2))).splitlines()
 
-    for line in lines:
-        bot.say('[W|A] {}'.format(line))
+    if len(lines) <= 3:
+        for line in lines:
+            bot.say('[W|A] {}'.format(line))
+    else:
+        for line in lines:
+            bot.notice('[W|A] {}'.format(line), trigger.nick)
 
 
 def wa_query(app_id, query):


### PR DESCRIPTION
Solves flood issue with things like `.wa cucumber` (many foods output tons of lines of nutrition facts) and other very lengthy results. This is the way to fix #7.

There's housekeeping etc. to do before merge/release, but this is all that really needs doing code-wise. Opening as a PR makes it easier to test. 😉 
