### PR TITLE
Always interpret input as UTF-8

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,13 @@ Changelog
 Ticket numbers in changelog entries can be looked up by visiting
 ``https://github.com/dgw/sopel-wolfram/issue/<number>``
 
+Unreleased
+----------
+
+Updates:
+
+* Unicode-encode query to avoid UnicodeEncodeError on non-ASCII characters
+
 sopel-wolfram v0.3.0 "So long!"
 -------------------------------
 

--- a/sopel_modules/wolfram/wolfram.py
+++ b/sopel_modules/wolfram/wolfram.py
@@ -50,6 +50,7 @@ def wa_query(app_id, query):
     if not app_id:
         return 'Wolfram|Alpha API app ID not provided.'
     client = wolframalpha.Client(app_id)
+    query = query.encode('utf-8').strip()
 
     try:
         result = client.query(query)


### PR DESCRIPTION
Simplest fix for #9 (but don't close that issue until this fix is ported into `master` after update to support `wolframalpha` 3.0).