### PR TITLE
Add support for wolframalpha 3.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,13 @@ Changelog
 Ticket numbers in changelog entries can be looked up by visiting
 ``https://github.com/dgw/sopel-wolfram/issue/<number>``
 
+Unreleased
+----------
+
+Updates:
+
+* Add support for wolframalpha 3.0 and allow pip to install any 2.x or 3.x version (#11)
+
 sopel-wolfram v0.3.1 "Nusumareta kuchibiru"
 -------------------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -7,9 +7,13 @@ Ticket numbers in changelog entries can be looked up by visiting
 Unreleased
 ----------
 
-Updates:
+Deprecated:
 
-* Add support for wolframalpha 3.0 and allow pip to install any 2.x or 3.x version (#11)
+* Support for wolframalpha < 2.4 has been dropped (#11)
+
+Added:
+
+* Support for wolframalpha 3.0 with fallback to 2.4 (#11)
 
 sopel-wolfram v0.3.1 "Nusumareta kuchibiru"
 -------------------------------------------

--- a/NEWS
+++ b/NEWS
@@ -7,10 +7,6 @@ Ticket numbers in changelog entries can be looked up by visiting
 Unreleased
 ----------
 
-Deprecated:
-
-* Support for wolframalpha < 2.4 has been dropped (#11)
-
 Added:
 
 * Support for wolframalpha 3.0 with fallback to 2.4 (#11)

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,15 @@ Sopel Wolfram\|Alpha module
 
 Wolfram\|Alpha module for Sopel IRC bot framework
 
+Requirements
+------------
+
+* Sopel 6.x
+* wolframalpha 2.4+
+
+Note: v0.4.0 drops support for old wolframalpha versions, but support for 2.4 remains on
+a transitional basis. An upcoming release will drop all support for wolframalpha < 3.0.
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,7 @@ Requirements
 * Sopel 6.x
 * wolframalpha 2.4+
 
-Note: v0.4.0 drops support for old wolframalpha versions, but support for 2.4 remains on
-a transitional basis. An upcoming release will drop all support for wolframalpha < 3.0.
+Note: Support for wolframalpha 3.0 was added in v0.4.0.
 
 Installation
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 sopel>=6.0,<7
-wolframalpha>=2.0,<4.0
+wolframalpha>=2.4,<4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 sopel>=6.0,<7
-wolframalpha>=2.0,<3.0
+wolframalpha>=2.0,<4.0

--- a/sopel_modules/wolfram/wolfram.py
+++ b/sopel_modules/wolfram/wolfram.py
@@ -68,8 +68,12 @@ def wa_query(app_id, query):
 
     try:
         try:
-            input = next(result.pods).text
-            output = next(result.results).text
+            texts = []
+            for pod in result.pods:
+                texts.append(pod.text)
+                if len(texts) >= 2:  # len() is O(1); this cheaply avoids copying more strings than needed
+                    break
+            input, output = texts[0], texts[1]
         except StopIteration:
             raise
         except (TypeError, AttributeError):


### PR DESCRIPTION
Allow pip to satisfy the requirement with any version between 2.0 (inclusive) and 4.0 (exclusive).

Some queries have different output when using 3.0 (vs. when using 2.x), but in most cases it appears that the change is from returning "No text-representable result" to returning some form of usable text, so I won't spend a ton of time trying to figure out why. It's an improvement.

Completes ~~part~~ all (revised May 10, 2017) of #5 (supporting both 2.x and 3.x).