### PR TITLE
Add setting: max_public, maximum lines to send to channels

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,18 @@ Changelog
 Ticket numbers in changelog entries can be looked up by visiting
 ``https://github.com/dgw/sopel-wolfram/issue/<number>``
 
+Unreleased
+----------
+
+New:
+
+* New configuration option max_public, a number defining the maximum number of lines
+  that can be sent without using NOTICEs. Default: 5 (#13)
+
+Updates:
+
+* Threshold for using NOTICEs is now 5 lines, up from the previous default of 3
+
 sopel-wolfram v0.3.1 "Nusumareta kuchibiru"
 -------------------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,7 @@ Unreleased
 
 New:
 
-* New configuration option max_public, a number defining the maximum number of lines
+* New configuration option `max_public`, a number defining the maximum number of lines
   that can be sent without using NOTICEs. Default: 5 (#13)
 
 Updates:

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ to Sopel’s configuration file:
 
     [wolfram]
     app_id = yourappidgoeshere
+    max_public = 5
 
 Usage
 -----

--- a/sopel_modules/wolfram/wolfram.py
+++ b/sopel_modules/wolfram/wolfram.py
@@ -15,11 +15,13 @@ import wolframalpha
 
 class WolframSection(StaticSection):
     app_id = ValidatedAttribute('app_id', default=None)
+    max_public = ValidatedAttribute('max_public', default=5)
 
 
 def configure(config):
     config.define_section('wolfram', WolframSection, validate=False)
     config.wolfram.configure_setting('app_id', 'Application ID')
+    config.wolfram.configure_setting('max_public', 'Maximum lines before sending answer in NOTICE')
 
 
 def setup(bot):
@@ -38,7 +40,7 @@ def wa_command(bot, trigger):
 
     lines = (msg or wa_query(bot.config.wolfram.app_id, trigger.group(2))).splitlines()
 
-    if len(lines) <= 3:
+    if len(lines) <= bot.config.wolfram.max_public:
         for line in lines:
             bot.say('[W|A] {}'.format(line))
     else:


### PR DESCRIPTION
Results longer than max_public lines will be sent in NOTICEs. Default 5.

Resolves #12.