### PR TITLE
Fallback to param-less W|A query if using params fails

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,9 @@ Requirements
 * Sopel 6.x
 * wolframalpha 2.4+
 
-Note: Support for wolframalpha 3.0 was added in v0.4.0.
+Note: Some features are unavailable when run with wolframalpha 2.4. Support for
+wolframalpha 2.4 is deprecated and will be removed in a future release. All bugs must
+be reported against sopel-wolfram with wolframalpha 3.0+.
 
 Installation
 ------------

--- a/sopel_modules/wolfram/wolfram.py
+++ b/sopel_modules/wolfram/wolfram.py
@@ -59,8 +59,16 @@ def wa_query(app_id, query, units='metric'):
         ('units', units),
     )
 
-    try:
-        result = client.query(input=query, params=params)
+    try:  # Remove this mess for the next bump after 0.4
+        try:  # wolframalpha 3.x supports extra stuff
+            result = client.query(input=query, params=params)  # This is the only necessary line post-0.4
+        except TypeError:  # fall back to query-only for 2.x
+            try:
+                result = client.query(query)
+            except:
+                raise  # send any exceptions to the outer level
+        except:
+            raise  # ditto; the 0.4 mess ends here
     except AssertionError:
         return 'Temporary API issue. Try again in a moment.'
     except Exception as e:


### PR DESCRIPTION
This means newer features might not work, but it's been too long to just drop support for the old library cold turkey. Dual support was promised for the upcoming release, and so it will have be deprecated for the next. Then this kludge can go.

Close #17. Disclaimer included in the README that things might not always work as expected with 2.4.