### PR TITLE
Remove ZIP sdist format from release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -10,8 +10,9 @@ rm dist/*
 
 # generate new distributions
 
-## source distributions for *nix & Windows
-python setup.py sdist --formats=gztar,zip
+## source distribution
+## PyPI only allows one format, so use the most common (.tar.gz)
+python setup.py sdist --formats=gztar
 
 ## binary wheels
 ### universal


### PR DESCRIPTION
PyPI stopped accepting multiple source distributions over a year ago, though there have been very few sopel-wolfram releases in that time (and so it wasn't really an issue). But there's no reason to build a release format that can't be uploaded to PyPI, especially since the only reason ZIP was being built was for GitHub -- which provides native ZIP downloads. (It also provides .tar.gz natively, but those must be built for PyPI regardless.)

Windows users who are using Python (and running an IRC bot) almost certainly have the necessary knowledge to extract .tar.gz archives under Windows, so removing ZIP files should have minimal impact to anyone. (And GitHub provides them anyway, just in case they are needed for some reason.)

Resolves #20.